### PR TITLE
Update create-svm-roles-minimum-privileges to fix quotation marks

### DIFF
--- a/install/create-svm-roles-minimum-privileges.adoc
+++ b/install/create-svm-roles-minimum-privileges.adoc
@@ -103,4 +103,4 @@ There are several ONTAP CLI commands you should run to create SVM roles and assi
 * `security login role create -vserver SVM_name -role SVM_Role_Name -cmddirname "vserver export-policy" -access all`
 * `security login role create -vserver SVM_name -role SVM_Role_Name -cmddirname "vserver iscsi" -access all`
 * `security login role create -vserver SVM_Name -role SVM_Role_Name -cmddirname "volume clone split status" -access all`
-* `security login role create -vserver SVM_name -role SVM_Role_Name -cmddirname “volume managed-feature” -access all`
+* `security login role create -vserver SVM_name -role SVM_Role_Name -cmddirname "volume managed-feature" -access all`


### PR DESCRIPTION
Curly quotation marks are used instead of straight ones for "volume managed-feature" permission. The command fails if copy-pasted to ONTAP CLI.